### PR TITLE
Issue openam#36 Remove dependency on ForgeRock Maven repositories

### DIFF
--- a/forgerock-guice-core/pom.xml
+++ b/forgerock-guice-core/pom.xml
@@ -12,6 +12,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014 ForgeRock AS.
+  Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -19,11 +20,11 @@
     <parent>
         <groupId>org.forgerock.commons</groupId>
         <artifactId>forgerock-guice</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>forgerock-guice-core</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
 
     <name>ForgeRock Guice Core</name>
     <description>ForgeRock Guice Core Library</description>

--- a/forgerock-guice-core/pom.xml
+++ b/forgerock-guice-core/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <artifactId>forgerock-guice</artifactId>
         <version>1.1.1-SNAPSHOT</version>
     </parent>

--- a/forgerock-guice-servlet/pom.xml
+++ b/forgerock-guice-servlet/pom.xml
@@ -13,6 +13,7 @@ Header, with the fields enclosed by brackets [] replaced by your own identifying
 information: "Portions Copyrighted [year] [name of copyright owner]".
 
 Copyright 2014 ForgeRock AS.
+Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -20,11 +21,11 @@ Copyright 2014 ForgeRock AS.
     <parent>
         <groupId>org.forgerock.commons</groupId>
         <artifactId>forgerock-guice</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>forgerock-guice-servlet</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
 
     <name>ForgeRock Guice Servlet</name>
     <description>ForgeRock Guice Servlet Library</description>

--- a/forgerock-guice-servlet/pom.xml
+++ b/forgerock-guice-servlet/pom.xml
@@ -19,7 +19,7 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <artifactId>forgerock-guice</artifactId>
         <version>1.1.1-SNAPSHOT</version>
     </parent>
@@ -32,7 +32,7 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>forgerock-guice-core</artifactId>
         </dependency>
         <dependency>

--- a/forgerock-guice-test/pom.xml
+++ b/forgerock-guice-test/pom.xml
@@ -21,7 +21,7 @@
 
     <parent>
         <artifactId>forgerock-guice</artifactId>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <version>1.1.1-SNAPSHOT</version>
     </parent>
 
@@ -33,7 +33,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>forgerock-guice-core</artifactId>
         </dependency>
     </dependencies>

--- a/forgerock-guice-test/pom.xml
+++ b/forgerock-guice-test/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -21,11 +22,11 @@
     <parent>
         <artifactId>forgerock-guice</artifactId>
         <groupId>org.forgerock.commons</groupId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>forgerock-guice-test</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
 
     <name>ForgeRock Guice Test</name>
     <description>ForgeRock Guice Test Library</description>

--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,12 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.forgerock</groupId>
+        <groupId>jp.openam</groupId>
         <artifactId>forgerock-parent</artifactId>
         <version>2.0.4</version>
     </parent>
 
-    <groupId>org.forgerock.commons</groupId>
+    <groupId>jp.openam.commons</groupId>
     <artifactId>forgerock-guice</artifactId>
     <version>1.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -91,19 +91,19 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>forgerock-bom</artifactId>
                 <version>1.0.0</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>forgerock-guice-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>forgerock-guice-servlet</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@ Header, with the fields enclosed by brackets [] replaced by your own identifying
 information: "Portions Copyrighted [year] [name of copyright owner]".
 
 Copyright 2014-2015 ForgeRock AS.
+Portions Copyrighted 2019 Open Source Solution Technology Corporation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -25,7 +26,7 @@ Copyright 2014-2015 ForgeRock AS.
 
     <groupId>org.forgerock.commons</groupId>
     <artifactId>forgerock-guice</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>ForgeRock Guice Library</name>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
 
     <name>ForgeRock Guice Library</name>
     <description>Common Guice implementation used by ForgeRock projects</description>
-    <url>http://commons.forgerock.org/forgerock-guice</url>
+    <url>https://github.com/openam-jp/forgerock-guice</url>
 
     <licenses>
         <license>
@@ -43,40 +43,16 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
         </license>
     </licenses>
 
-    <distributionManagement>
-        <site>
-            <id>community.internal.forgerock.com</id>
-            <name>ForgeRock Community</name>
-            <url>scp://community.internal.forgerock.com/var/www/vhosts/commons.forgerock.org/httpdocs/forgerock-guice</url>
-        </site>
-    </distributionManagement>
-
     <issueManagement>
-        <system>Jira</system>
-        <url>https://bugster.forgerock.org/jira/browse/COMMONS</url>
+        <system>GitHub</system>
+        <url>https://github.com/openam-jp/forgerock-guice/issues</url>
     </issueManagement>
 
     <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-guice.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-guice.git</developerConnection>
-        <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-guice/browse</url>
-      <tag>1.1.0</tag>
-  </scm>
-
-    <ciManagement>
-        <system>jenkins</system>
-        <url>https://builds.forgerock.org/job/Commons%20-%20ForgeRock%20Guice%20-%20trunk%20-%20postcommit</url>
-        <notifiers>
-            <notifier>
-                <type>mail</type>
-                <sendOnError>true</sendOnError>
-                <sendOnFailure>true</sendOnFailure>
-                <sendOnSuccess>false</sendOnSuccess>
-                <sendOnWarning>false</sendOnWarning>
-                <address>commons@forgerock.org</address>
-            </notifier>
-        </notifiers>
-    </ciManagement>
+        <connection>scm:git:https://github.com/openam-jp/forgerock-guice.git</connection>
+        <developerConnection>scm:git:git@github.com:openam-jp/forgerock-guice.git</developerConnection>
+        <url>https://github.com/openam-jp/forgerock-guice</url>
+    </scm>
 
     <properties>
         <guice.version>3.0</guice.version>
@@ -180,24 +156,5 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
             </plugin>
         </plugins>
     </reporting>
-
-    <repositories>
-        <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
     <parent>
         <groupId>jp.openam</groupId>
         <artifactId>forgerock-parent</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
 
     <groupId>jp.openam.commons</groupId>
@@ -93,7 +93,7 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
             <dependency>
                 <groupId>jp.openam.commons</groupId>
                 <artifactId>forgerock-bom</artifactId>
-                <version>1.0.0</version>
+                <version>4.1.2-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
## Analysis
This project is Dependency Injection Framework for ForgeRock projects.

In order to fix openam-jp/openam#36, this project also needs modification.

## Solution

* Remove ForgeRock repository tags in pom.xml
* Change Maven groupId
* Adjust maven dependency

## Install/Update
N/A

## Compatibility
N/A

## Performance
N/A

## I18N
N/A

## Testing
```
$ mvn install -f forgerock-parent
$ mvn install -f forgerock-bom
$ mvn install -f forgerock-build-tools
$ mvn install -f forgerock-guice
```

## Regression testing
N/A