### PR TITLE
Issue #2 InjectorConfigurationTest fails

### DIFF
--- a/forgerock-guice-core/src/test/java/org/forgerock/guice/core/InjectorConfigurationTest.java
+++ b/forgerock-guice-core/src/test/java/org/forgerock/guice/core/InjectorConfigurationTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.guice.core;
@@ -22,6 +23,7 @@ import java.lang.annotation.Annotation;
 import java.util.Set;
 
 import com.google.inject.Module;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -35,6 +37,12 @@ public class InjectorConfigurationTest {
     public void setUpClass() {
         defaultAnnotation = InjectorConfiguration.getModuleAnnotation();
         defaultModuleLoader = InjectorConfiguration.getGuiceModuleLoader();
+    }
+
+    @AfterClass
+    public void tearDownClass() {
+        InjectorConfiguration.setModuleAnnotation(defaultAnnotation);
+        InjectorConfiguration.setGuiceModuleLoader(defaultModuleLoader);
     }
 
     @BeforeMethod

--- a/forgerock-guice-core/src/test/java/org/forgerock/guice/core/InjectorHolderTest.java
+++ b/forgerock-guice-core/src/test/java/org/forgerock/guice/core/InjectorHolderTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyright 2019 Open Source Solution Technology Corporation
  */
 
 package org.forgerock.guice.core;
@@ -27,14 +28,23 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class InjectorHolderTest {
 
+    private GuiceModuleLoader defaultModuleLoader;
+
     @BeforeClass
-    public void setUp() {
+    public void setUpClass() {
+        defaultModuleLoader = InjectorConfiguration.getGuiceModuleLoader();
         InjectorConfiguration.setGuiceModuleLoader(new TestGuiceModuleLoader());
+    }
+
+    @AfterClass
+    public void tearDownClass() {
+        InjectorConfiguration.setGuiceModuleLoader(defaultModuleLoader);
     }
 
     @Test


### PR DESCRIPTION
## Analysis

The build log shows that the nested class of InjectorHolderTest appears in the InjectorConfigurationTest.

If you look at the code of InjectorHolderTest, you can see that the mothod of BeforeClass annotation set `InjectorHolderTest$TestGuiceModuleLoader` to InjectorConfiguration. And InjectorHolderTest does not restore InjectorConfiguration to its original state.

```
 33 public class InjectorHolderTest {
 34 
 35     @BeforeClass
 36     public void setUp() {
 37         InjectorConfiguration.setGuiceModuleLoader(new TestGuiceModuleLoader());
 38     }
```
Since InjectorConfiguration is a singleton, if InjectorConfigurationTest runs after InjectorHolderTest, `InjectorHolderTest$TestGuiceModuleLoader` will be passed to InjectorConfigurationTest. As a result, the error occurs.


## Solution

Restore InjectorConfiguration to its default state at the end of unit test.

## Testing

```
$ mvn test -f forgerock-guice-core
```