### PR TITLE
Issue forgerock-bom#2 Promote dependency management by BOM

### DIFF
--- a/forgerock-guice-core/pom.xml
+++ b/forgerock-guice-core/pom.xml
@@ -30,18 +30,6 @@
     <name>ForgeRock Guice Core</name>
     <description>ForgeRock Guice Core Library</description>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/forgerock-guice-core/pom.xml
+++ b/forgerock-guice-core/pom.xml
@@ -13,6 +13,7 @@
 
   Copyright 2014 ForgeRock AS.
   Portions Copyrighted 2019 Open Source Solution Technology Corporation
+  Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -29,11 +30,27 @@
     <name>ForgeRock Guice Core</name>
     <description>ForgeRock Guice Core Library</description>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <runOrder>alphabetical</runOrder>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <classifier>no_aop</classifier>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
         </dependency>
     </dependencies>
     

--- a/forgerock-guice-servlet/pom.xml
+++ b/forgerock-guice-servlet/pom.xml
@@ -14,6 +14,7 @@ information: "Portions Copyrighted [year] [name of copyright owner]".
 
 Copyright 2014 ForgeRock AS.
 Portions Copyrighted 2019 Open Source Solution Technology Corporation
+Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -37,7 +38,7 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
     

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@ Portions Copyrighted 2019 OGIS-RI Co., Ltd.
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@ information: "Portions Copyrighted [year] [name of copyright owner]".
 
 Copyright 2014-2015 ForgeRock AS.
 Portions Copyrighted 2019 Open Source Solution Technology Corporation
+Portions Copyrighted 2019 OGIS-RI Co., Ltd.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -53,11 +54,6 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
         <developerConnection>scm:git:git@github.com:openam-jp/forgerock-guice.git</developerConnection>
         <url>https://github.com/openam-jp/forgerock-guice</url>
     </scm>
-
-    <properties>
-        <guice.version>3.0</guice.version>
-        <servlet.api.version>2.5</servlet.api.version>
-    </properties>
 
     <modules>
         <module>forgerock-guice-core</module>
@@ -106,32 +102,6 @@ Portions Copyrighted 2019 Open Source Solution Technology Corporation
                 <groupId>jp.openam.commons</groupId>
                 <artifactId>forgerock-guice-servlet</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.inject</groupId>
-                <artifactId>guice</artifactId>
-                <version>${guice.version}</version>
-                <!-- Exclude aopalliance dependency due to ambiguous licensing. -->
-                <classifier>no_aop</classifier>
-                <exclusions>
-                    <exclusion>
-                        <groupId>aopalliance</groupId>
-                        <artifactId>aopalliance</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>${servlet.api.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-nop</artifactId>
-                <version>1.7.12</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Analysis
openam-jp/forgerock-bom#2

Since last year, security alerts have been sent from GitHub about Maven dependencies.
After forking this BOM project, I noticed alerts fixed in OpenAM were also occurring.
It's annoying to fix the same alert across multiple projects.

## Solution
- Move dependencies defined in multiple projects to BOM
- Use BOM in each project
- Do not overwrite the dependency version defined in BOM in each project
- If multiple versions of the same library are used, unify them to the new version

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-bom
- forgerock-build-tools
- forgerock--i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- opendj-sdk
- opendj
- openam

## Regression testing
There is no change in test results by test framework.
